### PR TITLE
Removed graphical editors from the setup page

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -19,9 +19,9 @@
     <p>
       Make sure you install, or have available, a text editor that
       you are comfortable with using.
-      When you're writing code, it's nice to have a text
-      editor that is optimized for writing code, with features
-      like automatic color-coding of key words.
+      Since we will be using a remote shell on for writing grid
+      jobs, we encourage using an editor such as <code>nano</code>,
+      <code>emacs</code> or <code>vi</code>.
     </p>
     <h4>The Bash Shell</h4>
     <p>
@@ -71,14 +71,6 @@
     <p>
       <code>nano</code> is the editor installed by the Software Carpentry Installer,
       it is a basic editor integrated into the lesson material.
-    </p>
-    <p>
-      <a href="http://notepad-plus-plus.org/">Notepad++</a> is a
-      popular free code editor for Windows.
-      Be aware that you must add its installation directory to your system path
-      in order to launch it from the command line
-      (or have other tools like Git launch it for you).
-      Please ask your instructor to help you do this.
     </p>
     <h4>Git Bash</h4>
     <p>
@@ -139,11 +131,7 @@
   <div class="span6">
     <h4>Editor</h4>
     <p>
-      We recommend
-      <a href="http://www.barebones.com/products/textwrangler/">Text Wrangler</a> or
-      <a href="http://www.sublimetext.com/">Sublime Text</a>.
-      In a pinch, you can use <code>nano</code>,
-      which should be pre-installed.
+      If you are unfamiliar with UNIX text editors we recommend <code>nano</code>, which should be preinstalled.
     </p>
     <h4>Bash</h4>
     <p>
@@ -197,9 +185,8 @@
   <div class="span6">
     <h4>Editor</h4>
     <p>
-      <a href="http://kate-editor.org/">Kate</a> is one option for Linux users.
-      In a pinch, you can use <code>nano</code>,
-      which should be pre-installed.
+      Editors such as <code>nano</code> and <code>vim</code>
+      are usually preinstalled. If you are unfamiliar with these, choose <code>nano</code>.
     </p>
     <h4>Bash</h4>
     <p>


### PR DESCRIPTION
I am opening this as a pull request for discussion purposes. 

I am of the opinion that we don't want to encourage users to use something like Kate, Text Wrangler, or Notepad++ if they will later be forced to use a UNIX-y editor when they submit to OSG.

Please comment.
